### PR TITLE
Add note about 2FA workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Options:
   --help                          Show this message and exit.
 ```
 
+## Note on 2FA
+
+When the destination site uses two-factor authentication (2FA), the workflow remains the same. Ensure that you complete the 2FA process and obtain the cookies/auth tokens/session tokens after 2FA. These tokens will be used in the workflow.
+
 ## Demo
 
 [![Demo Video](https://img.youtube.com/vi/7OJ4w5BCpQ0/0.jpg)](https://www.youtube.com/watch?v=7OJ4w5BCpQ0)

--- a/create_har.py
+++ b/create_har.py
@@ -21,6 +21,7 @@ async def open_browser_and_wait():
 
         input("Press Enter to continue and close the browser...")
 
+        # Ensure 2FA is completed before saving cookies
         cookies = await context.cookies()
 
         with open("cookies.json", "w") as f:


### PR DESCRIPTION
Related to #4

Add a note about the workflow required when the destination site uses 2FA.

* **README.md**
  - Add a section explaining the workflow for sites using 2FA.
  - Mention that cookies/auth tokens/session tokens should be obtained after completing 2FA.

* **create_har.py**
  - Add a comment to ensure 2FA is completed before saving cookies.

