### PR TITLE
Add pytest to dev-dependencies in pyproject.toml to fix CI test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ networkx = "^3.3"
 matplotlib = "^3.9.2"
 ipykernel = "^6.29.5"
 
+[tool.poetry.dev-dependencies]
+pytest = "^7.0"
+
 [tool.poetry.scripts]
 integuru = "integuru.__main__:cli"
 


### PR DESCRIPTION
This PR fixes below
![image](https://github.com/user-attachments/assets/efc6418c-be13-4d26-8aa3-4a6c9437d679)
