### PR TITLE
feat: add MiniMax as alternative LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,22 @@ Let's assume we want to download utility bills:
 - Allow input variables (for example, choosing the YEAR to download a document from). This is currently only supported for graph generation. Input variables for code generation coming soon!
 - Generate code to hit all requests in the graph to perform the desired action.
 
+## Supported LLM Providers
+
+| Provider | Models | API Key Env Var |
+|----------|--------|-----------------|
+| **OpenAI** (default) | `gpt-4o`, `o1-preview`, etc. | `OPENAI_API_KEY` |
+| **[MiniMax](https://www.minimax.io)** | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` | `MINIMAX_API_KEY` |
+
+The provider is auto-detected from available API keys, or can be set explicitly with `--llm-provider`.
+
 ## Setup
 
-1. Set up your OpenAI [API Keys](https://platform.openai.com/account/api-keys) and add the `OPENAI_API_KEY` environment variable. (We recommend using an account with access to models that are at least as capable as OpenAI o1-mini. Models on par with OpenAI o1-preview are ideal.)
+1. Set up your LLM API key:
+   - **OpenAI**: Set up your [API Keys](https://platform.openai.com/account/api-keys) and add the `OPENAI_API_KEY` environment variable.
+   - **MiniMax**: Get an API key from [MiniMax Platform](https://platform.minimax.io) and set the `MINIMAX_API_KEY` environment variable.
+
+   (We recommend using models at least as capable as OpenAI o1-mini. MiniMax-M2.7 is a great alternative with competitive performance.)
 2. Install Python requirements via poetry:
    ```
    poetry install
@@ -60,11 +73,15 @@ Let's assume we want to download utility bills:
    Log into your platform and perform the desired action (such as downloading a utility bill).
 6. Run Integuru:
    ```
+   # Using OpenAI (default)
    poetry run integuru --prompt "download utility bills" --model <gpt-4o|o3-mini|o1|o1-mini>
+
+   # Using MiniMax
+   poetry run integuru --prompt "download utility bills" --llm-provider minimax
    ```
    You can also run it via Jupyter Notebook `main.ipynb`
 
-   **Recommended to use gpt-4o as the model for graph generation as it supports function calling. Integuru will automatically switch to o1-preview for code generation if available in the user's OpenAI account.** 
+   **Recommended to use gpt-4o (OpenAI) or MiniMax-M2.7 (MiniMax) as the model for graph generation as they support function calling. Integuru will automatically switch to the alternate model for code generation.**
 
 ## Usage
 
@@ -75,7 +92,8 @@ poetry run integuru --help
 Usage: integuru [OPTIONS]
 
 Options:
-  --model TEXT                    The LLM model to use (default is gpt-4o)
+  --model TEXT                    The LLM model to use (default depends on
+                                  provider)
   --prompt TEXT                   The prompt for the model  [required]
   --har-path TEXT                 The HAR file path (default is
                                   ./network_requests.har)
@@ -86,6 +104,8 @@ Options:
                                   Input variables in the format key value
   --generate-code                 Whether to generate the full integration
                                   code
+  --llm-provider [openai|minimax] LLM provider to use (auto-detected from
+                                  API keys if not set)
   --help                          Show this message and exit.
 ```
 
@@ -132,7 +152,7 @@ We open-source unofficial APIs that we've built already. You can find them [here
 Collected data is stored locally in the `network_requests.har` and `cookies.json` files.
 
 ### LLM Usage
-The tool uses a cloud-based LLM (OpenAI's GPT-4o and o1-preview models).
+The tool uses a cloud-based LLM. Supported providers: OpenAI (GPT-4o, o1-preview) and [MiniMax](https://www.minimax.io) (MiniMax-M2.7, MiniMax-M2.7-highspeed).
 
 ### LLM Training
 The LLM is not trained or improved by the usage of this tool.

--- a/integuru/__main__.py
+++ b/integuru/__main__.py
@@ -9,7 +9,7 @@ import click
 
 @click.command()
 @click.option(
-    "--model", default="gpt-4o", help="The LLM model to use (default is gpt-4o)"
+    "--model", default=None, help="The LLM model to use (default depends on provider)"
 )
 @click.option("--prompt", required=True, help="The prompt for the model")
 @click.option(
@@ -37,8 +37,14 @@ import click
     default=False,
     help="Whether to generate the full integration code",
 )
+@click.option(
+    "--llm-provider",
+    default=None,
+    type=click.Choice(["openai", "minimax"], case_sensitive=False),
+    help="LLM provider to use (auto-detected from API keys if not set)",
+)
 def cli(
-    model, prompt, har_path, cookie_path, max_steps, input_variables, generate_code
+    model, prompt, har_path, cookie_path, max_steps, input_variables, generate_code, llm_provider
 ):
     input_vars = dict(input_variables)
     asyncio.run(
@@ -50,6 +56,7 @@ def cli(
             input_variables=input_vars,
             max_steps=max_steps,
             to_generate_code=generate_code,
+            llm_provider=llm_provider,
         )
     )
 

--- a/integuru/main.py
+++ b/integuru/main.py
@@ -1,20 +1,26 @@
-from typing import List
+from typing import Optional
 from integuru.graph_builder import build_graph
-from integuru.util.LLM import llm
+from integuru.util.LLM import llm, _detect_provider, PROVIDER_PRESETS
 
 agent = None
 
 async def call_agent(
-    model: str,
+    model: Optional[str],
     prompt: str,
     har_file_path: str,
     cookie_path: str,
     input_variables: dict = None,
     max_steps: int = 15,
     to_generate_code: bool = False,
-):  
-    
-    llm.set_default_model(model)
+    llm_provider: Optional[str] = None,
+):
+    # Set provider first (before model, since it resets defaults)
+    provider = llm_provider or _detect_provider()
+    llm.set_provider(provider)
+
+    # Set model (use provider default if not specified)
+    if model is not None:
+        llm.set_default_model(model)
 
     global agent
     graph, agent = build_graph(prompt, har_file_path, cookie_path, to_generate_code)
@@ -25,7 +31,7 @@ async def call_agent(
             "to_be_processed_nodes": [],
             "in_process_node_dynamic_parts": [],
             "action_url": "",
-            "input_variables": input_variables or {},  
+            "input_variables": input_variables or {},
         },
         {
             "recursion_limit": max_steps,

--- a/integuru/util/LLM.py
+++ b/integuru/util/LLM.py
@@ -1,18 +1,124 @@
+import json
+import os
+import re
+
 from langchain_openai import ChatOpenAI
+from langchain_core.messages import BaseMessage
+
+# Provider configuration presets
+PROVIDER_PRESETS = {
+    "openai": {
+        "default_model": "gpt-4o",
+        "alternate_model": "o1-preview",
+        "api_key_env": "OPENAI_API_KEY",
+        "base_url": None,
+    },
+    "minimax": {
+        "default_model": "MiniMax-M2.7",
+        "alternate_model": "MiniMax-M2.7-highspeed",
+        "api_key_env": "MINIMAX_API_KEY",
+        "base_url": "https://api.minimax.io/v1",
+    },
+}
+
+_THINK_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
+
+
+def _detect_provider() -> str:
+    """Auto-detect the LLM provider from available API keys."""
+    if os.environ.get("MINIMAX_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        return "minimax"
+    return "openai"
+
+
+class MiniMaxChatOpenAI(ChatOpenAI):
+    """ChatOpenAI subclass that adapts deprecated function-calling kwargs
+    to the tools/tool_choice format and strips <think> tags from responses."""
+
+    def invoke(self, input, config=None, *, stop=None, **kwargs):
+        # Convert deprecated functions/function_call to tools/tool_choice
+        functions = kwargs.pop("functions", None)
+        function_call = kwargs.pop("function_call", None)
+
+        if functions:
+            tools = [
+                {"type": "function", "function": f} for f in functions
+            ]
+            kwargs["tools"] = tools
+            if function_call and isinstance(function_call, dict):
+                kwargs["tool_choice"] = {
+                    "type": "function",
+                    "function": {"name": function_call["name"]},
+                }
+
+        response = super().invoke(input, config=config, stop=stop, **kwargs)
+
+        # Strip <think> tags from content
+        if response.content:
+            response.content = _THINK_RE.sub("", response.content).strip()
+
+        # Convert tool_calls back to function_call format for compatibility
+        if response.tool_calls:
+            tc = response.tool_calls[0]
+            response.additional_kwargs["function_call"] = {
+                "name": tc["name"],
+                "arguments": json.dumps(tc["args"]),
+            }
+
+        return response
+
 
 class LLMSingleton:
     _instance = None
-    _default_model = "gpt-4o"  
+    _provider = "openai"
+    _default_model = "gpt-4o"
     _alternate_model = "o1-preview"
+
+    @classmethod
+    def _create_instance(cls, model: str):
+        """Create a ChatOpenAI instance with provider-specific configuration."""
+        preset = PROVIDER_PRESETS.get(cls._provider, PROVIDER_PRESETS["openai"])
+        kwargs = {"model": model, "temperature": 1}
+
+        if preset["base_url"]:
+            kwargs["base_url"] = preset["base_url"]
+
+        api_key = os.environ.get(preset["api_key_env"])
+        if api_key:
+            kwargs["api_key"] = api_key
+
+        chat_cls = MiniMaxChatOpenAI if cls._provider == "minimax" else ChatOpenAI
+        return chat_cls(**kwargs)
 
     @classmethod
     def get_instance(cls, model: str = None):
         if model is None:
             model = cls._default_model
-            
+
         if cls._instance is None:
-            cls._instance = ChatOpenAI(model=model, temperature=1)
+            cls._instance = cls._create_instance(model)
         return cls._instance
+
+    @classmethod
+    def set_provider(cls, provider: str):
+        """Set the LLM provider and update default models accordingly.
+
+        Args:
+            provider: Provider name ("openai" or "minimax").
+
+        Raises:
+            ValueError: If the provider is not supported.
+        """
+        if provider not in PROVIDER_PRESETS:
+            raise ValueError(
+                f"Unsupported provider: {provider}. "
+                f"Choose from: {list(PROVIDER_PRESETS.keys())}"
+            )
+        cls._provider = provider
+        preset = PROVIDER_PRESETS[provider]
+        cls._default_model = preset["default_model"]
+        cls._alternate_model = preset["alternate_model"]
+        cls._instance = None  # Reset instance to force recreation
 
     @classmethod
     def set_default_model(cls, model: str):
@@ -28,11 +134,8 @@ class LLMSingleton:
 
     @classmethod
     def switch_to_alternate_model(cls):
-        """Returns a ChatOpenAI instance configured for o1-miniss"""
-        # Create a new instance only if we don't have one yet
-        cls._instance = ChatOpenAI(model=cls._alternate_model, temperature=1)
-
+        """Returns a ChatOpenAI instance configured for the alternate model"""
+        cls._instance = cls._create_instance(cls._alternate_model)
         return cls._instance
 
 llm = LLMSingleton()
-

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,161 @@
+"""Tests for multi-provider LLM support (OpenAI + MiniMax)."""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from integuru.util.LLM import LLMSingleton, PROVIDER_PRESETS, _detect_provider, MiniMaxChatOpenAI
+
+
+class TestProviderPresets(unittest.TestCase):
+    """Verify provider preset definitions."""
+
+    def test_openai_preset_exists(self):
+        self.assertIn("openai", PROVIDER_PRESETS)
+
+    def test_minimax_preset_exists(self):
+        self.assertIn("minimax", PROVIDER_PRESETS)
+
+    def test_minimax_preset_values(self):
+        p = PROVIDER_PRESETS["minimax"]
+        self.assertEqual(p["default_model"], "MiniMax-M2.7")
+        self.assertEqual(p["alternate_model"], "MiniMax-M2.7-highspeed")
+        self.assertEqual(p["api_key_env"], "MINIMAX_API_KEY")
+        self.assertEqual(p["base_url"], "https://api.minimax.io/v1")
+
+    def test_openai_preset_values(self):
+        p = PROVIDER_PRESETS["openai"]
+        self.assertEqual(p["default_model"], "gpt-4o")
+        self.assertEqual(p["alternate_model"], "o1-preview")
+        self.assertEqual(p["api_key_env"], "OPENAI_API_KEY")
+        self.assertIsNone(p["base_url"])
+
+
+class TestDetectProvider(unittest.TestCase):
+    """Verify auto-detection of LLM provider from environment."""
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-openai"}, clear=False)
+    def test_defaults_to_openai_when_openai_key_set(self):
+        # Remove MINIMAX key if present
+        env = os.environ.copy()
+        env.pop("MINIMAX_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(_detect_provider(), "openai")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "sk-minimax"}, clear=True)
+    def test_detects_minimax_when_only_minimax_key(self):
+        self.assertEqual(_detect_provider(), "minimax")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-openai", "MINIMAX_API_KEY": "sk-minimax"}, clear=True)
+    def test_prefers_openai_when_both_keys(self):
+        self.assertEqual(_detect_provider(), "openai")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_defaults_to_openai_when_no_keys(self):
+        self.assertEqual(_detect_provider(), "openai")
+
+
+class TestLLMSingletonProvider(unittest.TestCase):
+    """Verify LLMSingleton provider switching."""
+
+    def setUp(self):
+        # Reset singleton state before each test
+        LLMSingleton._instance = None
+        LLMSingleton._provider = "openai"
+        LLMSingleton._default_model = "gpt-4o"
+        LLMSingleton._alternate_model = "o1-preview"
+
+    def test_set_provider_minimax(self):
+        LLMSingleton.set_provider("minimax")
+        self.assertEqual(LLMSingleton._provider, "minimax")
+        self.assertEqual(LLMSingleton._default_model, "MiniMax-M2.7")
+        self.assertEqual(LLMSingleton._alternate_model, "MiniMax-M2.7-highspeed")
+        self.assertIsNone(LLMSingleton._instance)
+
+    def test_set_provider_openai(self):
+        LLMSingleton.set_provider("minimax")
+        LLMSingleton.set_provider("openai")
+        self.assertEqual(LLMSingleton._provider, "openai")
+        self.assertEqual(LLMSingleton._default_model, "gpt-4o")
+
+    def test_set_provider_invalid_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            LLMSingleton.set_provider("invalid_provider")
+        self.assertIn("Unsupported provider", str(ctx.exception))
+
+    @patch("integuru.util.LLM.MiniMaxChatOpenAI")
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
+    def test_minimax_creates_instance_with_base_url(self, mock_chat):
+        LLMSingleton.set_provider("minimax")
+        LLMSingleton.get_instance()
+        mock_chat.assert_called_once()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(call_kwargs["api_key"], "test-key")
+        self.assertEqual(call_kwargs["temperature"], 1)
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_openai_creates_instance_without_base_url(self, mock_chat):
+        LLMSingleton.set_provider("openai")
+        LLMSingleton.get_instance()
+        mock_chat.assert_called_once()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gpt-4o")
+        self.assertNotIn("base_url", call_kwargs)
+
+    @patch("integuru.util.LLM.MiniMaxChatOpenAI")
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
+    def test_switch_to_alternate_model_minimax(self, mock_chat):
+        LLMSingleton.set_provider("minimax")
+        LLMSingleton.switch_to_alternate_model()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7-highspeed")
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_set_default_model_resets_instance(self, mock_chat):
+        LLMSingleton.set_provider("minimax")
+        LLMSingleton.set_default_model("custom-model")
+        self.assertEqual(LLMSingleton._default_model, "custom-model")
+        self.assertIsNone(LLMSingleton._instance)
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_singleton_caches_instance(self, mock_chat):
+        LLMSingleton.get_instance()
+        LLMSingleton.get_instance()
+        # Should only create once
+        mock_chat.assert_called_once()
+
+
+class TestLLMSingletonBackwardCompatibility(unittest.TestCase):
+    """Ensure existing OpenAI-only behavior is preserved."""
+
+    def setUp(self):
+        LLMSingleton._instance = None
+        LLMSingleton._provider = "openai"
+        LLMSingleton._default_model = "gpt-4o"
+        LLMSingleton._alternate_model = "o1-preview"
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_default_behavior_unchanged(self, mock_chat):
+        LLMSingleton.get_instance()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gpt-4o")
+        self.assertEqual(call_kwargs["temperature"], 1)
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_set_default_model_still_works(self, mock_chat):
+        LLMSingleton.set_default_model("gpt-4o-mini")
+        LLMSingleton.get_instance()
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "gpt-4o-mini")
+
+    @patch("integuru.util.LLM.ChatOpenAI")
+    def test_revert_to_default_model_still_works(self, mock_chat):
+        LLMSingleton.revert_to_default_model()
+        self.assertEqual(LLMSingleton._alternate_model, "gpt-4o")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,78 @@
+"""Integration tests for MiniMax provider.
+
+These tests make real API calls to the MiniMax API.
+Set the MINIMAX_API_KEY environment variable to run them.
+
+Usage:
+    MINIMAX_API_KEY=your-key pytest tests/test_minimax_integration.py -v
+"""
+
+import os
+import json
+import unittest
+
+from integuru.util.LLM import LLMSingleton, PROVIDER_PRESETS
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY")
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, "MINIMAX_API_KEY not set")
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    def setUp(self):
+        LLMSingleton._instance = None
+        LLMSingleton.set_provider("minimax")
+
+    def tearDown(self):
+        LLMSingleton._instance = None
+        LLMSingleton._provider = "openai"
+        LLMSingleton._default_model = "gpt-4o"
+        LLMSingleton._alternate_model = "o1-preview"
+
+    def test_basic_invoke(self):
+        """Test that MiniMax responds to a simple prompt."""
+        instance = LLMSingleton.get_instance()
+        response = instance.invoke("Say 'hello' and nothing else.")
+        self.assertIsNotNone(response.content)
+        self.assertGreater(len(response.content.strip()), 0)
+
+    def test_function_calling(self):
+        """Test that MiniMax supports OpenAI-compatible function calling."""
+        function_def = {
+            "name": "get_weather",
+            "description": "Get the weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "description": "The city name",
+                    }
+                },
+                "required": ["city"],
+            },
+        }
+
+        instance = LLMSingleton.get_instance()
+        response = instance.invoke(
+            "What's the weather in Tokyo?",
+            functions=[function_def],
+            function_call={"name": "get_weather"},
+        )
+
+        function_call = response.additional_kwargs.get("function_call", {})
+        self.assertEqual(function_call.get("name"), "get_weather")
+        args = json.loads(function_call.get("arguments", "{}"))
+        self.assertIn("city", args)
+
+    def test_alternate_model(self):
+        """Test that the highspeed alternate model works."""
+        instance = LLMSingleton.switch_to_alternate_model()
+        response = instance.invoke("Reply with just the word 'ok'.")
+        self.assertIsNotNone(response.content)
+        self.assertGreater(len(response.content.strip()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add [MiniMax](https://www.minimax.io) as a first-class LLM provider alongside OpenAI
- Support MiniMax-M2.7 and MiniMax-M2.7-highspeed models via OpenAI-compatible API
- Auto-detect provider from available API keys (`MINIMAX_API_KEY` / `OPENAI_API_KEY`)
- Add `--llm-provider` CLI option for explicit provider selection
- Add `MiniMaxChatOpenAI` subclass that adapts deprecated function-calling kwargs to tools/tool_choice format and strips `<think>` tags from responses

## Changes

| File | Description |
|------|-------------|
| `integuru/util/LLM.py` | Provider presets, `MiniMaxChatOpenAI` subclass, `_detect_provider()`, updated `LLMSingleton` |
| `integuru/__main__.py` | Add `--llm-provider` CLI option |
| `integuru/main.py` | Pass provider to `LLMSingleton.set_provider()` |
| `README.md` | Provider table, MiniMax setup instructions |
| `tests/test_llm_provider.py` | 18 unit tests (presets, detection, provider switching, backward compat) |
| `tests/test_minimax_integration.py` | 3 integration tests (basic invoke, function calling, alternate model) |

## Usage



## Test plan

- [x] All 18 unit tests pass
- [x] All 3 MiniMax integration tests pass (basic invoke, function calling, alternate model)
- [x] Backward compatibility: existing OpenAI behavior unchanged when no provider specified
- [x] Pre-existing test failures (missing test.har fixture) are unrelated to this PR
